### PR TITLE
Change text for Action from fixes to fix

### DIFF
--- a/contribution/contribution-guidelines.md
+++ b/contribution/contribution-guidelines.md
@@ -23,7 +23,7 @@ The `Tag` is one of the following:
 `Message` is short description of what have been done
 `Action` - depends on used task tracking, but in general case:
 * `refs` - link commit to task
-* `fixes` - closes task, moving it to testing state
+* `fix` - closes task, moving it to testing state
 
 The message summary should be a one-sentence description of the change. The issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use `[refs #1234]` instead of `[fixes #1234]`.
 

--- a/contribution/contribution-guidelines.md
+++ b/contribution/contribution-guidelines.md
@@ -22,8 +22,8 @@ The `Tag` is one of the following:
 
 `Message` is short description of what have been done
 `Action` - depends on used task tracking, but in general case:
-* `refs` - link commit to task
-* `fix` - closes task, moving it to testing state
+* `refs` or `ref` - link commit to task
+* `fixes` or `fix` - closes task, moving it to testing state
 
 The message summary should be a one-sentence description of the change. The issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use `[refs #1234]` instead of `[fixes #1234]`.
 


### PR DESCRIPTION
@valorkin It's too annoying to use the similar texts for Tag and Action (Fix and fixes). I've checked 5 or even more  times just to be sure i remember which word should be used. And refs i've forgot 2 times: should it be ref or refs.
